### PR TITLE
Blank method names are ok

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     compile group: 'commons-io', name: 'commons-io', version: '2.0.1'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.1'
-    compile group: 'com.google.guava', name: 'guava', version: '14.0.1'
+    compile group: 'com.google.guava', name: 'guava', version: 'r09'
 	compile group: 'com.googlecode.jatl', name: 'jatl', version: '0.2.2'
 	compile group: 'org.apache.velocity', name: 'velocity', version: '1.6.2'
 	compile group: 'org.antlr', name: 'antlr', version: '3.3'

--- a/src/main/java/randori/compiler/internal/codegen/js/emitter/IdentifierEmitter.java
+++ b/src/main/java/randori/compiler/internal/codegen/js/emitter/IdentifierEmitter.java
@@ -159,12 +159,24 @@ public class IdentifierEmitter extends BaseSubEmitter implements
             getModel().addDependency(definition, node);
         }
 
+
+
         if (node.getParent() instanceof IMemberAccessExpressionNode)
         {
-            write(node.getName());
+            // in this case, it might be a fully-qualified expression was already written out
+            // i.e. new foo.bar.Baz();
+            // so we can't just use getExportQualifiedName();
+
+            if (MetaDataUtils.hasJavaScriptName(definition)) {
+                write(MetaDataUtils.getExportQualifiedName(definition));
+            } else {
+                write(node.getName());
+            }
+
         }
         else
         {
+
             String name = MetaDataUtils.getExportQualifiedName(definition);
             write(name);
         }

--- a/src/main/java/randori/compiler/internal/utils/MetaDataUtils.java
+++ b/src/main/java/randori/compiler/internal/utils/MetaDataUtils.java
@@ -306,6 +306,14 @@ public class MetaDataUtils
             return name;
 
         String value = tag.getAttributeValue(ATT_NAME);
+
+        // if you're efficient, you can do
+        // [JavaScriptMethod("methodName")]
+        // instead of
+        // [JavaScriptMethod(name="methodName")]
+        if (value == null)
+            value = tag.getValue();
+
         if (value != null)
             return value;
 
@@ -426,8 +434,8 @@ public class MetaDataUtils
     {
         String path = node.getSourcePath();
         File file = new File(path).getParentFile();
-        String reletivePath = node.getAttributeValue(ATT_FILE);
-        File open = new File(file, reletivePath);
+        String relativePath = node.getAttributeValue(ATT_FILE);
+        File open = new File(file, relativePath);
         String result = "";
         try
         {
@@ -451,8 +459,8 @@ public class MetaDataUtils
 
         String path = node.getSourcePath();
         File file = new File(path).getParentFile();
-        String reletivePath = tag.getAttributeValue(ATT_FILE);
-        File open = new File(file, reletivePath);
+        String relativePath = tag.getAttributeValue(ATT_FILE);
+        File open = new File(file, relativePath);
         String result = "";
         try
         {

--- a/src/main/java/randori/compiler/internal/utils/RandoriUtils.java
+++ b/src/main/java/randori/compiler/internal/utils/RandoriUtils.java
@@ -167,20 +167,6 @@ public class RandoriUtils
         return sb.toString();
     }
 
-    public static boolean isJQueryStaticJ(IExpressionNode left,
-            IExpressionNode right)
-    {
-        if (left instanceof IIdentifierNode && right instanceof IIdentifierNode)
-        {
-            IIdentifierNode ileft = (IIdentifierNode) left;
-            IIdentifierNode iright = (IIdentifierNode) right;
-            if (ileft.getName().equals("JQueryStatic")
-                    && iright.getName().equals("J"))
-                return true;
-        }
-        return false;
-    }
-
     public static boolean isConstantMemberAccess(IExpressionNode left,
             IExpressionNode right, ICompilerProject project)
     {

--- a/src/test/gen/demo/application/hmss/EchoBehaviorTest.java
+++ b/src/test/gen/demo/application/hmss/EchoBehaviorTest.java
@@ -40,11 +40,11 @@ public class EchoBehaviorTest extends RandoriTestBase
     }
 
     @Test
-    public void test_onRegister()
+    public void test_initialize()
     {
-        IFunctionNode node = findFunction("onRegister", classNode);
+        IFunctionNode node = findFunction("initialize", classNode);
         visitor.visitFunction(node);
-        assertOut("behaviors.EchoBehavior.prototype.onRegister = function() {"
+        assertOut("behaviors.EchoBehavior.prototype.initialize = function() {"
                 + "\n\tthis.decoratedElement.innerText = \"Echo\";\n}");
     }
 

--- a/src/test/gen/demo/application/hmss/LabServiceTest.java
+++ b/src/test/gen/demo/application/hmss/LabServiceTest.java
@@ -17,9 +17,9 @@ public class LabServiceTest extends RandoriTestBase
     {
         IFunctionNode node = findFunction("LabService", classNode);
         visitor.visitFunction(node);
-        assertOut("services.LabService = function(xmlHttpRequest, gadgets) {\n\t"
+        assertOut("services.LabService = function(xmlHttpRequest, targets) {\n\t"
                 + "this.path = null;\n\trandori.service.AbstractService.call("
-                + "this, xmlHttpRequest);\n\tthis.gadgets = gadgets;\n\tthis.path = "
+                + "this, xmlHttpRequest);\n\tthis.targets = targets;\n\tthis.path = "
                 + "\"assets\\/data\\/gadgets.txt\";\n}");
     }
     

--- a/src/test/gen/demo/application/hmss/VerticalTabsTest.java
+++ b/src/test/gen/demo/application/hmss/VerticalTabsTest.java
@@ -55,13 +55,13 @@ public class VerticalTabsTest extends RandoriTestBase
     }
 
     @Test
-    public void test_onRegister()
+    public void test_initialize()
     {
-        IFunctionNode node = findFunction("onRegister", classNode);
+        IFunctionNode node = findFunction("initialize", classNode);
         visitor.visitFunction(node);
-        assertOut("behaviors.VerticalTabs.prototype.onRegister = function() {"
+        assertOut("behaviors.VerticalTabs.prototype.initialize = function() {"
                 + "\n\tthis.listChanged.add($createStaticDelegate(this, this.listChangedHandler));"
-                + "\n\trandori.behaviors.List.prototype.onRegister.call(this);\n}");
+                + "\n\trandori.behaviors.List.prototype.initialize.call(this);\n}");
     }
 
     @Test

--- a/src/test/gen/functional/tests/annotation/JavaScriptMethodTest.java
+++ b/src/test/gen/functional/tests/annotation/JavaScriptMethodTest.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package functional.tests.annotation;
+
+import functional.tests.FunctionalTestBase;
+import org.apache.flex.compiler.tree.as.IFunctionNode;
+import org.junit.Test;
+
+public class JavaScriptMethodTest extends FunctionalTestBase {
+    @Test
+    public void emptyAnnotation_withInstanceMethodCall_doesNotAddDot() {
+        IFunctionNode fnode = findFunction("testTimeout", classNode);
+
+        visitor.visitFunction(fnode);
+
+        assertOut(getTypeUnderTest() + ".prototype.testTimeout"
+                + " = function(timeout) {\n\tvar timer = timeout(function() {\n\t\treturn;\n\t}, 2000);\n\ttimer.cancelTimer();\n}");
+    }
+
+    @Test
+    public void emptyAnnotation_withStaticMethodCall_doesNotAddDot() {
+        IFunctionNode fnode = findFunction("testJQueryStaticJ", classNode);
+
+        visitor.visitFunction(fnode);
+
+        assertOut(getTypeUnderTest() + ".prototype.testJQueryStaticJ = function() {\n\tjQuery(\"sup\");\n\tjQuery(\"sup2\");\n}");
+    }
+
+    @Override
+    protected String getTypeUnderTest () {
+        return "functional.tests.annotation.JavaScriptMethodTest";
+    }
+}

--- a/src/test/java/randori/compiler/internal/projects/RandoriBundleProjectTest.java
+++ b/src/test/java/randori/compiler/internal/projects/RandoriBundleProjectTest.java
@@ -1,19 +1,19 @@
 /***
  * Copyright 2013 Teoti Graphix, LLC.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- * 
- * 
+ *
+ *
  * @author Michael Schmalle <mschmalle@teotigraphix.com>
  */
 
@@ -169,7 +169,11 @@ public class RandoriBundleProjectTest extends RandoriTestCaseBase
 
         File build = new File(TestConstants.RandoriASFramework
                 + "/randori-compiler/temp/build");
-        FileUtils.deleteDirectory(build);
+
+        FileUtils.deleteQuietly(build);
+
+        // TODO: find out why this fails intermittently
+        //FileUtils.deleteDirectory(build);
     }
 
     @Test
@@ -318,7 +322,7 @@ public class RandoriBundleProjectTest extends RandoriTestCaseBase
 
         configuration.setSDKPath(getTestDataPath() + "/sdk/randori-sdk.rbl");
         configuration.addExternalBundlePath(hmssProjectPath
-                + "/LabModule/libs/CommonModule.rbl");
+                + "1/LabModule/libs/CommonModule.rbl");
 
         project.configure(configuration);
         boolean success = project.compile(true, true);
@@ -364,7 +368,7 @@ public class RandoriBundleProjectTest extends RandoriTestCaseBase
         arguments.setJsOutputAsFiles(true);
 
         //arguments.addBundlePath(hmssProjectPath + "/libs/CommonModule.rbl");
-        arguments.addBundlePath(hmssProjectPath + "/libs/LabModule.rbl");
+        arguments.addBundlePath(hmssProjectPath + "2/libs/LabModule.rbl");
 
         arguments.setSDKPath(getTestDataPath() + "/sdk/randori-sdk.rbl");
 

--- a/src/test/resources/functional/functional/tests/annotation/JavaScriptMethodTest.as
+++ b/src/test/resources/functional/functional/tests/annotation/JavaScriptMethodTest.as
@@ -1,0 +1,21 @@
+package functional.tests.annotation {
+
+import functional.tests.annotation.support.jsmethod.AngularTimeoutServiceExample;
+import randori.jquery.JQueryStatic;
+
+public class JavaScriptMethodTest {
+
+	public function testTimeout (timeout : AngularTimeoutServiceExample) : void {
+		var timer : Object = timeout.createTimer(function () : void {
+			return;
+		}, 2000);
+
+		timer.cancelTimer();
+	}
+
+	public function testJQueryStaticJ () : void {
+		JQueryStatic.J("sup");
+		randori.jquery.JQueryStatic.J("sup2");
+	}
+}
+}

--- a/src/test/resources/functional/functional/tests/annotation/support/jsmethod/AngularTimeoutServiceExample.as
+++ b/src/test/resources/functional/functional/tests/annotation/support/jsmethod/AngularTimeoutServiceExample.as
@@ -1,0 +1,15 @@
+package functional.tests.annotation.support.jsmethod {
+
+[JavaScript(export="false")]
+public class AngularTimeoutServiceExample {
+
+	[JavaScriptMethod("")]
+	public function createTimer (fn : Function, delay : Number = 0, invokeApply : Boolean = true) : Object {
+		return {};
+	}
+
+	public function cancelTimer (obj : Object) : Boolean {
+		return false;
+	}
+}
+}


### PR DESCRIPTION
Made the JavaScriptMethod metadata work like you'd expect with a blank method name.

Useful for if something can be called as a function and treated as an object.

Examples include jQuery and Angular's TimeoutService (http://docs.angularjs.org/api/ng.$timeout)

This also has the failing test fixes in it as well.
